### PR TITLE
Add initial set of I/O interfaces

### DIFF
--- a/src/TreeInterfaces.cc
+++ b/src/TreeInterfaces.cc
@@ -21,6 +21,8 @@ using namespace std;
 
 namespace SColdQcdCorrelatorAnalysis {
 
+  // helper methods ===========================================================
+
   // --------------------------------------------------------------------------
   //! Get a particular entry from a generic TTree-derived object
   // --------------------------------------------------------------------------
@@ -79,6 +81,24 @@ namespace SColdQcdCorrelatorAnalysis {
   template int64_t Interfaces::LoadTree(TTree* tree, const uint64_t entry, int& current);
   template int64_t Interfaces::LoadTree(TChain* tree, const uint64_t entry, int& current);
   template int64_t Interfaces::LoadTree(TNtuple* tree, const uint64_t entry, int& current);
+
+
+
+  // BaseTreeIO methods =======================================================
+
+  // TODO
+  std::string Interfaces::BaseTreeIO::MakeBranchName() const {return "";}
+  std::string Interfaces::BaseTreeIO::MakeLeafList(const Typ type) const {return "";}
+
+  // TODO
+  void Interfaces::BaseTreeIO::SetInputBranch0D(const std::string name, <TYPE>& address, TTree* tree) {return;}
+  void Interfaces::BaseTreeIO::SetInputBranch1D(const std::string name, <TYPE>& address, TTree* tree) {return;}
+  void Interfaces::BaseTreeIO::SetInputBranch2D(const std::string name, <TYPE>& address, TTree* tree) {return;}
+
+  // TODO
+  void Interfaces::BaseTreeIO::SetOutputBranch0D(const std::string name, <TYPE>& address, TTree* tree) {return;}
+  void Interfaces::BaseTreeIO::SetOutputBranch1D(const std::string name, <TYPE>& address, TTree* tree) {return;}
+  void Interfaces::BaseTreeIO::SetOutputBranch2D(const std::string name, <TYPE>& address, TTree* tree) {return;}
 
 }  // end SColdQcdCorrelatorAnalysis namespace
 

--- a/src/TreeInterfaces.h
+++ b/src/TreeInterfaces.h
@@ -12,6 +12,7 @@
 
 // c++ utilities
 #include <limits>
+#include <string>
 // root libraries
 #include <TTree.h>
 #include <TChain.h>
@@ -27,8 +28,105 @@ namespace SColdQcdCorrelatorAnalysis {
 
     // tree interfaces --------------------------------------------------------
 
+    // helper methods
     template <typename T> int64_t GetEntry(T* tree, const uint64_t entry);
     template <typename T> int64_t LoadTree(T* tree, const uint64_t entry, int& current);
+
+    // ========================================================================
+    //! Base tree I/O interface
+    // ========================================================================
+    /*! Base interface for I/O between TTree's and the
+     *  various info objects used throughout the
+     *  sPHENIX Cold QCD ENC analysis framework.
+     *
+     *  n.b. only a handful of types are defined for
+     *  setting branches; others can always be added
+     *  later.
+     *
+     *  TODO gist is that all of the tedious branch setting
+     *  is done here, then:
+     *    (1) Derived classes are made for each *Info type
+     *        (e.g. JetInfo) which
+     *        - Tell how to translate each type into a
+     *          group of atomic types, one for each
+     *          member
+     *        - And tell how to add a scalar (0D), vector
+     *          (1D), or tensor (2D) of each member
+     *    (2) Then in the analysis modules, an interface is
+     *        defined that
+     *        - Defines the input/output of the module, and
+     *        - Maps the input/output *Info types onto the
+     *          necessary intermediate, atomic types
+     *  The goal is to have an interface that looks
+     *  something like this:
+     *
+     *        // the tree
+     *        TTree* tree
+     *
+     *        // the output
+     *        REvtInfo             evt;
+     *        std::vector<JetInfo> jets;
+     *
+     *        // the interfaces
+     *        REvtInfoIO evtIO( Dim::Zero );
+     *        JetInfoIO  jetIO( Dim::One );
+     *
+     *        /... somewhere in the code... /
+     *        evtIO.AddOutputBranch(evt,  "Tag", tree);
+     *        jetIO.AddOutputBranch(jets, "Tag", tree);
+     *
+     *        /... further on in the code .../
+     *        evtIO.SetValues( evt );
+     *        jetIO.SetValues( jets );
+     *        tree -> Fill();
+     *
+     *  So some additional thoughts:
+     *    - This is going to be painful, but for this to work
+     *      I might need to define scalar, 1d vector, and
+     *      2d vector atomics as members of each dervied
+     *      IO class..
+     *    - The Set/GetValues functions might be easily
+     *      handled with a parameter pack...
+     *    - I might need to instead just pass the dimension
+     *      as a parameter to the SetInput/OutputBranch
+     *      and Set/GetValues functions...
+     *    - Might want to template all the classes so that
+     *      it works out-of-the-box for TTrees, TChains, and
+     *      TNtuples
+     */
+    class BaseTreeIO {
+
+      public:
+
+        //! Type of branch
+        enum class Typ {Double, Bool, UInt, Int};
+
+        //! Dimensionality of branch
+        enum class Dim {Zero, One, Two};
+
+        // default ctor/dtor
+        BaseTreeIO()  {};
+        ~BaseTreeIO() {};
+
+      protected:
+
+        // make branch names/lists
+        virtual std::string MakeBranchName() const;
+        virtual std::string MakeLeafList(const Typ type) const;
+
+      private:
+
+        // set input branches
+        void SetInputBranch0D(const std::string name, <TYPE>& address, TTree* tree);
+        void SetInputBranch1D(const std::string name, <TYPE>& address, TTree* tree);
+        void SetInputBranch2D(const std::string name, <TYPE>& address, TTree* tree);
+
+        // set output branches
+        void SetOutputBranch0D(const std::string name, <TYPE>& address, TTree* tree);
+        void SetOutputBranch1D(const std::string name, <TYPE>& address, TTree* tree);
+        void SetOutputBranch2D(const std::string name, <TYPE>& address, TTree* tree);
+
+    };  // end BaseTreeID
 
   }  // end Interfaces namespace
 }  // end SColdQcdCorrealtorAnalysis namespace


### PR DESCRIPTION
This PR implements the initial round of Tree I/O interfaces for the Info classes. These interfaces move all the tedious setting branches/translating between vectors of members vs. vectors of classes to centralized locations.

### To-Do's
- [ ] Implement base class
- [ ] Implement instantiations for
       - [ ] JetInfo
       - [ ] CstInfo
       - [ ] REvtInfo
       - [ ] GEvtInfo
       - [ ] ParInfo